### PR TITLE
Bug fix for 'cannot use in' operator to search 'message' in null.' as…

### DIFF
--- a/src/generate-report.ts
+++ b/src/generate-report.ts
@@ -248,6 +248,7 @@ export class GenerateCtrfReport {
 
     if (
       lastAttempt?.error !== undefined &&
+      lastAttempt?.error !== null &&
       'message' in lastAttempt.error &&
       'stack' in lastAttempt.error
     ) {


### PR DESCRIPTION
The error we received was:

TypeError: Cannot use 'in' operator to search for 'message' in null
    at GenerateCtrfReport.extractFailureDetails (...\node\modulescypress-ctrf-json-reporter\dist\generate-report.js:183:23)

The error property could have been null, which it was in my framework. 