### PR TITLE
chore: align staged publish workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
Align release workflow with the ctrf-js staged publish template and normalize actions/checkout and actions/setup-node to @v6 in main workflow where present.